### PR TITLE
Fix inconsistent untrimmed `base_class` key

### DIFF
--- a/src/gdext/icons.rs
+++ b/src/gdext/icons.rs
@@ -219,9 +219,9 @@ fn find_children(base_class_to_nodes: &mut HashMap<String, Vec<String>>) -> Resu
                 };
                 // Eliminate the , or ).
                 base_class.pop();
-                let base_class_trimmed = base_class.trim();
-                if !base_class_to_nodes.contains_key(base_class_trimmed) {
-                    base_class_to_nodes.insert(base_class_trimmed.to_owned(), Vec::new());
+                base_class = base_class.trim().to_owned();
+                if !base_class_to_nodes.contains_key(&base_class) {
+                    base_class_to_nodes.insert(base_class.clone(), Vec::new());
                 }
                 found_base = true;
             } else if found_base & !line.starts_with("///") & line.contains("struct") {


### PR DESCRIPTION
The second use of `base_class` [here](https://github.com/sylbeth/gdext-generation/blob/4daa8ea2cf5edfdd7f1980558145f99044a55de4/src/gdext/icons.rs#L237) isn't trimmed, resulting in the `expect` panic. I've applied the trim to the `base_class` value directly so its guaranteed to be the same key used for the `insert` and the `get_mut`.